### PR TITLE
late loading option

### DIFF
--- a/src/src/main.lua
+++ b/src/src/main.lua
@@ -54,10 +54,34 @@ local function on_reload()
 	import 'reload.lua'
 end
 
+local function on_ready_late()
+	-- what to do when we are ready after all other mods
+	--   but not re-do on reload.
+	if config.enabled == false then return end
+
+	import 'ready_late.lua'
+end
+
+local function on_reload_late()
+	-- what to do when we are ready after all other mods
+	--   but also again on every reload.
+	-- only do things that are safe to run over and over.
+	if config.enabled == false then return end
+
+	import 'reload_late.lua'
+end
+
 -- this allows us to limit certain functions to not be reloaded.
-local loader = reload.auto_single()
+local loader = reload.auto_multiple()
 
 -- this runs only when modutil and the game's lua is ready
 modutil.once_loaded.game(function()
-	loader.load(on_ready, on_reload)
+	loader.load("early", on_ready, on_reload)
+end)
+
+-- again but loaded later than other mods
+rom.on_all_mods_loaded(function()
+	modutil.once_loaded.game(function()
+		loader.load("late", on_ready_late, on_reload_late)
+	end)
 end)

--- a/src/src/main.lua
+++ b/src/src/main.lua
@@ -80,7 +80,7 @@ modutil.once_loaded.game(function()
 end)
 
 -- again but loaded later than other mods
-rom.on_all_mods_loaded(function()
+mods.on_all_mods_loaded(function()
 	modutil.once_loaded.game(function()
 		loader.load("late", on_ready_late, on_reload_late)
 	end)

--- a/src/src/ready_late.lua
+++ b/src/src/ready_late.lua
@@ -1,0 +1,9 @@
+---@meta _
+-- globals we define are private to our plugin!
+---@diagnostic disable: lowercase-global
+
+-- here is where your mod sets up all the things it will do after all other mods load.
+-- this file will not be reloaded if it changes during gameplay
+-- 	so you will most likely want to have it reference
+--	values and functions later defined in `reload_late.lua`.
+

--- a/src/src/reload_late.lua
+++ b/src/src/reload_late.lua
@@ -1,0 +1,7 @@
+---@meta _
+-- globals we define are private to our plugin!
+---@diagnostic disable: lowercase-global
+
+-- this file will be reloaded if it changes during gameplay,
+-- 	so only assign to values or define things here.
+


### PR DESCRIPTION
Useful for using ModUtil's `Context.Wrap.Static` idomatically, as this way it will pick up wraps from mods that load later.

`Context.Wrap.Static` can be used to avoid an issue with `Context.Wrap`

https://github.com/SGG-Modding/ModUtil/issues/11

Still an open question as to if Override will cause issues with this.

https://github.com/SGG-Modding/ModUtil/issues/9