### PR TITLE
Node20 deprecation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,7 @@ env:
   source-dir: src/
   artifact-name: hades2-mod-template.zip
   artifact-content-type: application/zip
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   release:
@@ -33,14 +34,15 @@ jobs:
           fi
 
       - name: Checkout files
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
 
       - name: Rotate unreleased section in changelog
-        uses: thomaseizinger/keep-a-changelog-new-release@77ac767b2f7f6edf2ee72ab3364ed26667086f96
+        uses: baynezy/ChangeLogger.Action@6e3ad430f08e13698bb01027a13ba4349b0143cc
         with:
           tag: ${{ inputs.tag }}
+          log-path: ${{ env.changelog }}
 
       - name: Build template
         run: |
@@ -48,7 +50,7 @@ jobs:
           zip ../${{ env.artifact-name }} -r .
 
       - name: Upload artifact to workflow
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ env.artifact-name }}
           path: ${{ env.artifact-name }}

--- a/src/.github/workflows/release.yaml
+++ b/src/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ env:
   thunderstore-config: thunderstore.toml
   build-dir: build
   artifact-content-type: application/zip
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   release:
@@ -37,14 +38,15 @@ jobs:
           fi
 
       - name: Checkout files
-        uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           lfs: true
 
       - name: Rotate unreleased section in changelog
-        uses: thomaseizinger/keep-a-changelog-new-release@77ac767b2f7f6edf2ee72ab3364ed26667086f96
+        uses: baynezy/ChangeLogger.Action@6e3ad430f08e13698bb01027a13ba4349b0143cc
         with:
           tag: ${{ inputs.tag }}
+          log-path: ${{ env.changelog }}
 
       - name: Rotate version in Thunderstore CLI config
         run: |
@@ -65,7 +67,7 @@ jobs:
           echo "artifact-path=${{ env.build-dir }}/${ARTIFACT_NAME}" >> "$GITHUB_ENV"
 
       - name: Upload artifact to workflow
-        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f
         with:
           name: ${{ env.artifact-name }}
           path: ${{ env.artifact-path }}


### PR DESCRIPTION
Addresses this:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

- Force Node24 in both `release.yaml`
- update `actions/checkout` version
- update `actions/upload-artifact` version
- replace `thomaseizinger/keep-a-changelog-new-release` with `baynezy/ChangeLogger.Action`