### PR TITLE
remove create-release/upload-release-asset

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,6 @@ env:
   changelog: CHANGELOG.md
   source-dir: src/
   artifact-name: hades2-mod-template.zip
-  artifact-content-type: application/zip
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
@@ -66,24 +65,15 @@ jobs:
           git tag ${{ inputs.tag }} --annotate --message "Release ${{ inputs.tag }}"
           git push origin HEAD:${{ github.ref_name }} --tags
 
-      - name: Create release
+      - name: Create release and upload artifact
         if: ${{ !inputs.is-dry-run }}
-        id: release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
-        with:
-          release_name: ${{ inputs.tag }}
-          tag_name: ${{ inputs.tag }}
-          commitish: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload artifact to release
-        if: ${{ !inputs.is-dry-run }}
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_name: ${{ env.artifact-name }}
-          asset_path: ${{ env.artifact-name }}
-          asset_content_type: ${{ env.artifact-content-type }}
+        run: |
+          gh release create \
+            '${{ inputs.tag }}' \
+            '${{ env.artifact-name }}' \
+            --title '${{ inputs.tag }}' \
+            --repo '${{ github.repository }}' \
+            --target '${{ github.ref_name }}' \
+            --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/.github/workflows/release.yaml
+++ b/src/.github/workflows/release.yaml
@@ -22,7 +22,6 @@ env:
   changelog: CHANGELOG.md
   thunderstore-config: thunderstore.toml
   build-dir: build
-  artifact-content-type: application/zip
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
@@ -89,24 +88,15 @@ jobs:
           git tag ${{ inputs.tag }} --annotate --message "Release ${{ inputs.tag }}"
           git push origin HEAD:${{ github.ref_name }} --tags
 
-      - name: Create release
-        id: release
+      - name: Create release and upload artifact
         if: ${{ !inputs.is-dry-run }}
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e
-        with:
-          release_name: ${{ inputs.tag }}
-          tag_name: ${{ inputs.tag }}
-          commitish: ${{ github.ref_name }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload artifact to release
-        if: ${{ !inputs.is-dry-run }}
-        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5
-        with:
-          upload_url: ${{ steps.release.outputs.upload_url }}
-          asset_name: ${{ env.artifact-name }}
-          asset_path: ${{ env.artifact-path }}
-          asset_content_type: ${{ env.artifact-content-type }}
+        run: |
+          gh release create \
+            '${{ inputs.tag }}' \
+            '${{ env.artifact-path }}' \
+            --title '${{ inputs.tag }}' \
+            --repo '${{ github.repository }}' \
+            --target '${{ github.ref_name }}' \
+            --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replaces `create-release` and `upload-release-asset` with direct `gh` commands